### PR TITLE
Adding dragonflydb defragmenations metrics.

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -138,6 +138,7 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			"allocator_rss_ratio":  "allocator_rss_ratio",
 			"allocator_rss_bytes":  "allocator_rss_bytes",
 
+			"comitted_memory":          "comitted_memory_bytes",
 			"used_memory":              "memory_used_bytes",
 			"used_memory_rss":          "memory_used_rss_bytes",
 			"used_memory_peak":         "memory_used_peak_bytes",
@@ -213,6 +214,9 @@ func NewRedisExporter(redisURI string, opts Options) (*Exporter, error) {
 			"tracking_total_keys":     "tracking_total_keys",
 			"tracking_total_items":    "tracking_total_items",
 			"tracking_total_prefixes": "tracking_total_prefixes",
+                        "defrag_attempt_total":    "defrag_attempt_total",
+                        "defrag_realloc_total":    "defrag_realloc_total",
+                        "defrag_task_invocation_total": "defrag_task_invocation_total",
 
 			// # Replication
 			"connected_slaves":               "connected_slaves",


### PR DESCRIPTION
Redis exporter is compatible with https://github.com/dragonflydb/dragonfly, its latest version [v0.12.0](https://github.com/dragonflydb/dragonfly/releases/tag/v0.12.0) has active defragmentation feature with statistics available in `info all` redis command. We need to convert those stats into metrics.